### PR TITLE
🐳 Chore: TLS certificate verification error for L1 RPC connections

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -12,6 +12,8 @@ RUN make geth
 # -------------------------------------------------------------------------
 FROM ubuntu:jammy
 
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /op-geth/build/bin/geth /usr/local/bin/

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -21,6 +21,8 @@ RUN make op-node
 # -------------------------------------------------------------------------
 FROM ubuntu:jammy
 
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /optimism/op-node/bin/op-node /usr/local/bin/


### PR DESCRIPTION
# Problem
- https://github.com/giwa-io/node/issues/1

# Solution

Added ca-certificates package to both Docker containers (node and geth) to provide the necessary root certificates for TLS verification.

# Changes

- Updated node/Dockerfile to install ca-certificates
- Updated geth/Dockerfile to install ca-certificates

This ensures the containers can properly verify SSL/TLS certificates when connecting to external HTTPS endpoints.