### PR TITLE
chore: update base images upgrade for consistency

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-bullseye AS builder
+FROM golang:1.23.0-bookworm AS builder
 
 RUN git clone https://github.com/ethereum-optimism/op-geth.git /op-geth
 
@@ -10,7 +10,7 @@ RUN git checkout $OPGETH_VERSION
 
 RUN make geth
 # -------------------------------------------------------------------------
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 WORKDIR /app
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,11 +1,11 @@
-FROM rust:1.82.0-bullseye AS just-builder
+FROM rust:1.92-bookworm AS just-builder
 
 WORKDIR /app
 
 RUN cargo install just
 RUN cp $(which just) .
 # --------------------------------------------------------
-FROM golang:1.24.10-bullseye AS builder
+FROM golang:1.24.10-bookworm AS builder
 
 RUN git clone https://github.com/ethereum-optimism/optimism.git /optimism
 
@@ -19,7 +19,7 @@ COPY --from=just-builder /app/just /usr/local/bin/
 
 RUN make op-node
 # -------------------------------------------------------------------------
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request updates the base operating system and language images used in both the `geth/Dockerfile` and `node/Dockerfile` to newer versions. These changes help ensure compatibility with newer dependencies and improve security by using more recent OS releases.

**Base image upgrades:**

* Updated the Golang and Rust builder images from `bullseye` to `bookworm` in both `geth/Dockerfile` and `node/Dockerfile`, and upgraded Rust from `1.82.0` to `1.92` in `node/Dockerfile`. [[1]](diffhunk://#diff-57bf361e926558d17f7008495aba3ac09431cc9fbc3287ad47e68c12417dd866L1-R1) [[2]](diffhunk://#diff-e3718e3964930481779418c2836c5afa460848f3e49a9800a78f35cf65ff0401L1-R8)
* Changed the final base image from `ubuntu:jammy` to `ubuntu:noble` in both Dockerfiles to use the latest Ubuntu LTS release. [[1]](diffhunk://#diff-57bf361e926558d17f7008495aba3ac09431cc9fbc3287ad47e68c12417dd866L13-R13) [[2]](diffhunk://#diff-e3718e3964930481779418c2836c5afa460848f3e49a9800a78f35cf65ff0401L22-R22)