### PR TITLE
Upgrade execution and consensus client versions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
       context: .
       dockerfile: ${CLIENT}/Dockerfile
       args:
-        OPGETH_VERSION: v1.101603.5
-        RETH_VERSION: v1.9.3
+        OPGETH_VERSION: v1.101609.1
+        RETH_VERSION: v1.11.0
     env_file:
       - ${NETWORK_ENV:-.env.sepolia}
     ports:
@@ -40,7 +40,7 @@ services:
       context: .
       dockerfile: ./node/Dockerfile
       args:
-        OPNODE_VERSION: v1.16.3
+        OPNODE_VERSION: v1.16.7
     env_file:
       - ${NETWORK_ENV:-.env.sepolia}
     environment:

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-bookworm AS builder
+FROM golang:1.24.0-bookworm AS builder
 
 RUN git clone https://github.com/ethereum-optimism/op-geth.git /op-geth
 


### PR DESCRIPTION
Upgrade op-geth, op-reth, op-node and Go builder image to latest stable versions.

- op-geth: v1.101603.5 → v1.101609.1
- op-reth: v1.9.3 → v1.11.0
- op-node: v1.16.3 → v1.16.7
- Go builder: 1.23.0 → 1.24.0

Closes #25
