### PR TITLE
deprecate op-geth in preparation for karst hardfork

### DIFF
--- a/.env.sepolia
+++ b/.env.sepolia
@@ -7,6 +7,11 @@
 # GETH CONFIGURATION #
 #====================#
 
+# NOTE: op-geth (CLIENT=geth) is deprecated and will stop following GIWA Sepolia
+#       after the Karst hardfork (2026-07-06 06:00 UTC). Migrate to reth (CLIENT=reth).
+#       The GETH_* variables below are also consumed by the reth entrypoint.
+#       See: https://docs.giwa.io/notices/giwa-chain/op-geth-sunset
+
 # CHAIN SPECIFIC
 GENESIS_FILE=sepolia-genesis.json
 GETH_NETWORKID=91342

--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ This repository provides everything you need to run your own node on the GIWA ne
 
 ### Execution Client
 > Choose your preferred execution client by setting the `CLIENT` environment variable.
+>
+> ⚠️ **Deprecation:** `op-geth` will be removed after the Karst hardfork and cannot follow GIWA Sepolia once Karst activates (2026-07-06 06:00 UTC). Use `reth` (default); migrate any `geth` nodes before Karst. See the [op-geth sunset notice](https://docs.giwa.io/notices/giwa-chain/op-geth-sunset).
 
-| Variable | Description                                | Default |
-|----------|--------------------------------------------|---------|
-| `CLIENT` | Execution client (`reth` or `geth`)        | `reth`  |
+| Variable | Description                                       | Default |
+|----------|---------------------------------------------------|---------|
+| `CLIENT` | Execution client (`reth`, or `geth` — deprecated) | `reth`  |
 
 ### Sync Configuration
 

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -1,3 +1,6 @@
+# DEPRECATED: op-geth will be removed after the Karst hardfork and cannot follow
+#             GIWA Sepolia once Karst activates. Use reth (CLIENT=reth) instead.
+#             See: https://docs.giwa.io/notices/giwa-chain/op-geth-sunset
 FROM golang:1.24.0-bookworm AS builder
 
 ARG OPGETH_VERSION

--- a/geth/entrypoint.sh
+++ b/geth/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euxo pipefail
 
+echo "WARNING: op-geth is deprecated and will stop following GIWA after the Karst hardfork."
+echo "         Migrate to reth (CLIENT=reth). See: https://docs.giwa.io/notices/giwa-chain/op-geth-sunset"
+
 if [ -n "${GENESIS_FILE-}" ]; then
   geth init "${GENESIS_FILE}"
 fi


### PR DESCRIPTION
### Description
`op-geth` cannot follow GIWA Sepolia once the Karst hardfork activates (`Mon 06 Jul 2026 06:00:00 UTC`), as op-geth does not support Karst. This PR announces the deprecation ahead of the hardfork while keeping the `geth` option available for now.

- Add an op-geth deprecation notice to the Execution Client section in the README, and mark `geth` as deprecated in the `CLIENT` table
- Add a deprecation banner to the `GETH CONFIGURATION` section in `.env.sepolia` (the `GETH_*` variables are also consumed by the reth entrypoint, so they are left in place)
- Add a deprecation notice to `geth/Dockerfile` and a runtime warning to `geth/entrypoint.sh`

The `geth` client option and build path are intentionally left functional in this PR. Removing op-geth entirely will follow in a separate PR after Karst activates.

See: https://docs.giwa.io/notices/giwa-chain/op-geth-sunset

Closes #34
