### PR TITLE
fix op-reth link: optimism repo has no main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This repository provides everything you need to run your own node on the GIWA ne
 | `OP_NODE_L1_BEACON`  | Your L1 beacon node endpoint       |
 
 ### Execution Client
-GIWA nodes run [op-reth](https://github.com/ethereum-optimism/optimism/tree/main/rust/op-reth) as the execution client.
+GIWA nodes run [op-reth](https://github.com/ethereum-optimism/optimism/tree/develop/rust/op-reth) as the execution client.
 
 > [!NOTE]
 > op-geth is no longer supported. It cannot follow GIWA once the Karst hardfork is active. See the [op-geth sunset notice](https://docs.giwa.io/notices/giwa-chain/op-geth-sunset).


### PR DESCRIPTION
The op-reth link in the Execution Client section 404s:

```
https://github.com/ethereum-optimism/optimism/tree/main/rust/op-reth
```

`ethereum-optimism/optimism` has no `main` branch — its default is `develop`, so every `/tree/main/…` URL into that repo fails. The path itself is fine; only the branch name is wrong.

Verified against the API rather than the page, because two things mislead here:

- `GET /repos/ethereum-optimism/optimism/contents/rust/op-reth?ref=develop` returns the directory with its 15 entries (`bin`, `crates`, `DockerfileOp`, …), so the target is real.
- Requesting the tree URL over HTTP returns **200 with a "not found" page body**, so a status-code check alone would have called the broken link healthy and the fixed one no better.

I also checked the obvious-looking alternative, `ethereum-optimism/op-reth`, and deliberately did **not** point the link there: that repository is archived and was last pushed 2025-02-16, so it would trade a broken link for a stale one.

No open PR in this repo touches this line. Single word changed, no other edits.
